### PR TITLE
add missing `.DirIcon`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -69,6 +69,7 @@ cp "${DESKTOP_FILE}" "share/applications/com.mitchellh.ghostty.desktop"
 ln -s "com.mitchellh.ghostty.desktop" "share/applications/ghostty.desktop"
 ln -s "share/applications/com.mitchellh.ghostty.desktop" .
 ln -s "share/icons/hicolor/256x256/apps/com.mitchellh.ghostty.png" .
+ln -s "share/icons/hicolor/256x256/apps/com.mitchellh.ghostty.png" .DirIcon
 
 # bundle all libs
 xvfb-run -a -- sharun l -p -v -e -s -k \


### PR DESCRIPTION
fixes this issue from a random user on discord 👀

![image](https://github.com/user-attachments/assets/967dd594-bce8-4cb0-aa05-b8bde83d9308)


btw citron does have it so I don't know xd
