### PR TITLE
fix `tip` releases updating to stable

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,6 +24,7 @@ BUILD_ARGS="
 	-Dgtk-x11=true"
 
 if [ "${GHOSTTY_VERSION}" = "tip" ]; then
+	export UPINFO="gh-releases-zsync|$(echo "${GITHUB_REPOSITORY}" | tr '/' '|')|tip|Ghostty-*$ARCH.AppImage.zsync"
 	wget "https://github.com/ghostty-org/ghostty/releases/download/tip/ghostty-source.tar.gz" -O "ghostty-${GHOSTTY_VERSION}.tar.gz"
 	wget "https://github.com/ghostty-org/ghostty/releases/download/tip/ghostty-source.tar.gz.minisig" -O "ghostty-${GHOSTTY_VERSION}.tar.gz.minisig"
 	GHOSTTY_VERSION="$(tar -tf "ghostty-${GHOSTTY_VERSION}.tar.gz" --wildcards "*zig.zon.txt" | awk -F'[-/]' '{print $2"-"$3}')"


### PR DESCRIPTION
`latest` tag in github shows the latest stable release, it will not show pre-releases. 

So to fix this issue `UPINFO` is redeclared with the right tag when `[ "${GHOSTTY_VERSION}" = "tip" ]`.