### PR TITLE
temp fix for opengl loader issue

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -62,6 +62,9 @@ export ICON="./ghostty-${GHOSTTY_VERSION}/zig-out/share/icons/hicolor/256x256/ap
 ./quick-sharun ./ghostty-${GHOSTTY_VERSION}/zig-out/bin/ghostty
 cp -rf ./ghostty-${GHOSTTY_VERSION}/zig-out/share/* ./AppDir/share/
 echo 'unset ARGV0' >> ./AppDir/.env
+# temp fix for https://github.com/pkgforge-dev/ghostty-appimage/issues/93
+ln -s /usr/share/glvnd/egl_vendor.d/10_nvidia.json ./AppDir/share/glvnd/egl_vendor.d/10_nvidia.json
+
 ./uruntime2appimage
 
 mkdir -p ./dist


### PR DESCRIPTION
For most people this symlink will be broken. 

It is for those with the prop nvidia driver installed where it is useful, since the opengl loader will open the `10_nvidia.json` first before `50_mesa.json` which should prevent the current bug. 

However we need to make sure the broken link does not cause issues for people without the prop nvidia driver.