### PR TITLE
add `gdk-pixbuf2-mini`

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -54,7 +54,7 @@ esac
 # Install Debloated Pkgs
 wget "${DEBLOATED_PKGS}" -O /tmp/get-debloated-pkgs.sh
 chmod a+x /tmp/get-debloated-pkgs.sh
-sh /tmp/get-debloated-pkgs.sh --add-opengl --prefer-nano gtk4-mini libxml2-mini
+sh /tmp/get-debloated-pkgs.sh --add-opengl --prefer-nano gtk4-mini libxml2-mini gdk-pixbuf2-mini
 
 # Download & install other dependencies
 # zig: https://ziglang.org


### PR DESCRIPTION
This is gdk without glycin (over 20 MiB of binaries). 